### PR TITLE
Fixes panic in UnwrapError

### DIFF
--- a/error_test.go
+++ b/error_test.go
@@ -1,9 +1,12 @@
 package eal
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
+	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/labstack/echo/v4"
@@ -114,6 +117,114 @@ func TestNewHTTPError(t *testing.T) {
 			}
 			if msg != tt.wantInnerMsg {
 				t.Errorf("got inner HTTP message: %s, want: %s", msg, tt.wantInnerMsg)
+			}
+		})
+	}
+}
+
+type testErr struct{ e error }
+
+func (t testErr) Error() string   { return "testErr" }
+func (t testErr) Temporary() bool { return false }
+func (t testErr) Unwrap() error   { return t.e }
+
+type testSetLogFieldsErr struct{ e error }
+
+func (t testSetLogFieldsErr) Error() string                         { return "testErr" }
+func (t testSetLogFieldsErr) SetLogFields(f map[string]interface{}) { f["set_log_fields"] = true }
+func (t testSetLogFieldsErr) Unwrap() error                         { return t.e }
+
+// nonComparableError is an error where the struct contain a slice and can't be used as a key in a map.
+type nonComparableError struct {
+	lines []string
+}
+
+func (e nonComparableError) Error() string {
+	return strings.Join(e.lines, ",")
+}
+
+var statTestErr = errors.New("test error")
+
+func TestUnwrapError(t *testing.T) {
+	elf := func(err error, fields Fields) {
+		fields["registeredErrorLogFunctions"] = true
+		fields["type_"+reflect.TypeOf(err).String()] = true
+		if f, ok := err.(interface{ Timeout() bool }); ok {
+			fields["timeout"] = f.Timeout()
+		}
+		if f, ok := err.(interface{ Temporary() bool }); ok {
+			fields["temporary"] = f.Temporary()
+		}
+	}
+	RegisterErrorLogFunc(elf, statTestErr, context.DeadlineExceeded, (*testErr)(nil), (*nonComparableError)(nil))
+	for _, tt := range []struct {
+		name string
+		err  error
+		want map[string]interface{}
+	}{
+		{
+			name: "nil",
+			err:  nil,
+		},
+		{
+			name: "static_error",
+			err:  statTestErr,
+			want: map[string]interface{}{"error_message": "test error", "registeredErrorLogFunctions": true, "type_*errors.errorString": true},
+		},
+		{
+			name: "testErr-struct",
+			err:  testErr{},
+			want: map[string]interface{}{"error_message": "testErr"},
+		},
+		{
+			name: "testErr-pointer",
+			err:  &testErr{},
+			want: map[string]interface{}{"error_message": "testErr", "registeredErrorLogFunctions": true, "temporary": false, "type_*eal.testErr": true},
+		},
+		{
+			name: "context.DeadlineExceeded",
+			err:  fmt.Errorf("test: %w", context.DeadlineExceeded),
+			want: map[string]interface{}{"error_message": "test: context deadline exceeded", "registeredErrorLogFunctions": true, "timeout": true, "temporary": true, "type_context.deadlineExceededError": true},
+		},
+		{
+			name: "context.DeadlineExceeded_wrapped_in_testErr",
+			err:  &testErr{e: context.DeadlineExceeded},
+			want: map[string]interface{}{"error_message": "testErr", "registeredErrorLogFunctions": true, "timeout": true, "temporary": true, "type_*eal.testErr": true, "type_context.deadlineExceededError": true},
+		},
+		{
+			name: "testSetLogFieldsErr-struct",
+			err:  testSetLogFieldsErr{},
+			want: map[string]interface{}{"error_message": "testErr", "set_log_fields": true},
+		},
+		{
+			name: "testSetLogFieldsErr-pointer",
+			err:  &testSetLogFieldsErr{},
+			want: map[string]interface{}{"error_message": "testErr", "set_log_fields": true},
+		},
+		{
+			name: "testSetLogFieldsErr_wrapped_in_testErr",
+			err:  &testErr{e: testSetLogFieldsErr{}},
+			want: map[string]interface{}{"error_message": "testErr", "registeredErrorLogFunctions": true, "set_log_fields": true, "temporary": false, "type_*eal.testErr": true},
+		},
+		{
+			name: "ApiError-pointer",
+			err:  &nonComparableError{lines: []string{"test", "lines"}},
+			want: map[string]interface{}{"error_message": "test,lines", "registeredErrorLogFunctions": true, "type_*eal.nonComparableError": true},
+		},
+		{
+			name: "ApiError-struct",
+			err:  nonComparableError{lines: []string{"test", "lines"}},
+			want: map[string]interface{}{"error_message": "test,lines"},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got := make(map[string]any)
+			UnwrapError(tt.err, got)
+			if tt.err == nil && len(got) == len(tt.want) {
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("\n got: %v,\nwant: %v", got, tt.want)
 			}
 		})
 	}

--- a/error_test.go
+++ b/error_test.go
@@ -207,12 +207,12 @@ func TestUnwrapError(t *testing.T) {
 			want: map[string]interface{}{"error_message": "testErr", "registeredErrorLogFunctions": true, "set_log_fields": true, "temporary": false, "type_*eal.testErr": true},
 		},
 		{
-			name: "ApiError-pointer",
+			name: "nonComparableError-pointer",
 			err:  &nonComparableError{lines: []string{"test", "lines"}},
 			want: map[string]interface{}{"error_message": "test,lines", "registeredErrorLogFunctions": true, "type_*eal.nonComparableError": true},
 		},
 		{
-			name: "ApiError-struct",
+			name: "nonComparableError-struct",
 			err:  nonComparableError{lines: []string{"test", "lines"}},
 			want: map[string]interface{}{"error_message": "test,lines"},
 		},


### PR DESCRIPTION
If an error were passed to eal.UnwrapError that wasn't hashable/comparable, a panic were raised when we tried to use it as a map key. Now we check in UnwrapError if the error is comparable before we try to use it as a map key.

If one tries to call RegisterErrorLogFunc with an error that isn't comparable we'll still raise a panic since until we can log those, there is no point to call RegisterErrorLogFunc, and that will in most cases happen when initializing the program.

The only workaround currently is to either ignore log augmentation for those errors, or change the type to use pointer-receivers to force the creation of those errors to return a pointer to the un-comparable error struct.

This commit also fixes some comments and another bug in the internal esl.errorLogger where the "jwt_text" log field contained the error bitfield and not the jwt.ValidationError text.